### PR TITLE
Add super simple ANSI colour escape codes to EUnit console output

### DIFF
--- a/Sources/Utils/ConsoleTestListener.pas
+++ b/Sources/Utils/ConsoleTestListener.pas
@@ -18,6 +18,7 @@ type
     method TestStarted(Test: ITest); virtual;
     method TestFinished(TestResult: ITestResult); virtual;
     method RunFinished(TestResult: ITestResult); virtual;
+    UseAnsiColorOutput: Boolean;
   end;
 
 implementation
@@ -40,11 +41,19 @@ begin
   if TestResult.Test.Kind <> TestKind.Testcase then
       dec(Offset, 2);
 
+  var Failed := "Failed";
+  var Succeeded := "Succeeded";
+  
+  if UseAnsiColorOutput then begin
+    Failed := #27"[1m"#27"[31mFailed"#27"[0m";
+    Succeeded := #27"[32mSucceded"#27"[0m";
+  end;
+
   var Message: String;
   if TestResult.State = TestState.Failed then
-    Message := String.Format("{0}{1} finished. State: Failed. Message: {2}", StringOffset, TestResult.Name, TestResult.Message)
+    Message := String.Format("{0}{1} finished. State: {2}. Message: {3}", StringOffset, TestResult.Name, Failed, TestResult.Message)
   else
-    Message := String.Format("{0}{1} finished. State: Succeded.", StringOffset, TestResult.Name);
+    Message := String.Format("{0}{1} finished. State: {2}.", StringOffset, TestResult.Name, Succeeded);
 
   Output(Message);
 end;


### PR DESCRIPTION
@dwarfland 
Adds super simple ANSI colour escape codes to EUnit console output to make the output easier to read.
Makes Failed red, Succeeded green.

Please excuse failures in my Pascal. It's literally been 25 years.

![image](https://cloud.githubusercontent.com/assets/1787624/16686795/d9d8c134-4557-11e6-9dc1-1bf6fabf501a.png)
