### PR TITLE
Added TestActivity.pas to Cooper.Tests.Android.elements

### DIFF
--- a/Sources/.gitattributes
+++ b/Sources/.gitattributes
@@ -1,1 +1,0 @@
-*.pas linguist-language=Oxygene

--- a/Sources/.gitattributes
+++ b/Sources/.gitattributes
@@ -1,0 +1,1 @@
+*.pas linguist-language=Oxygene

--- a/Tests/Cooper.Tests.Android.elements
+++ b/Tests/Cooper.Tests.Android.elements
@@ -85,6 +85,7 @@
     </ItemGroup>
     <ItemGroup>
         <Compile Include="Main\Android\MainActivity.pas"/>
+        <Compile Include="Sources\Android\TestActivity.pas"/>
         <Compile Include="Sources\Asserts\Assert.pas"/>
         <Compile Include="Sources\Asserts\BooleanAssert.pas"/>
         <Compile Include="Sources\Asserts\DoubleAssert.pas"/>


### PR DESCRIPTION
TestActivity.pas was missing from Cooper.Tests.Android.elements, so EUnit Android projects currently show "No definition found" for TestActivity.