### PR TITLE
Fixed crash on Android when adding AndroidX package references to EUnit project

### DIFF
--- a/Sources/Discovery/Android/ContextDiscovery.pas
+++ b/Sources/Discovery/Android/ContextDiscovery.pas
@@ -26,8 +26,12 @@ begin
   var List := new List<NativeType>;
 
   for Item: String in Content do begin
-    if (Item <> nil) and (not Item.contains("%")) and (not Item.contains("$")) then
+    if (Item <> nil) and (not Item.contains("%")) and (not Item.contains("$")) then try
       List.Add(&Class.forName(Item));
+    except
+      on E: java.lang.ClassNotFoundException do;
+      on E: java.lang.NoClassDefFoundError do;
+    end;
   end;
 
   exit List.ToArray;


### PR DESCRIPTION
Weird ClassNotFoundException at startup on androidx.fragment.lint.FragmentIssueRegistry whenever androix.appcompat is referenced from an EUnit (Android) project